### PR TITLE
Bugfix/correct invalid email response

### DIFF
--- a/src/main/webapp/app/account/password-reset/init/password-reset-init.component.ts
+++ b/src/main/webapp/app/account/password-reset/init/password-reset-init.component.ts
@@ -35,7 +35,7 @@ export class PasswordResetInitComponent implements OnInit, AfterViewInit {
             this.success = 'OK';
         }, (response) => {
             this.success = null;
-            if (response.status === 400 && response.data === 'email address not registered') {
+            if (response.status === 400 && response._body === 'email address not registered') {
                 this.errorEmailNotExists = 'ERROR';
             } else {
                 this.error = 'ERROR';

--- a/src/test/javascript/spec/app/account/password-reset/init/password-reset-init.component.spec.ts
+++ b/src/test/javascript/spec/app/account/password-reset/init/password-reset-init.component.spec.ts
@@ -77,7 +77,7 @@ describe('Component Tests', () => {
             inject([PasswordResetInitService], (service: PasswordResetInitService) => {
                 spyOn(service, 'save').and.returnValue(Observable.throw({
                     status: 400,
-                    data: 'email address not registered'
+                    _body: 'email address not registered'
                 }));
                 comp.resetAccount.email = 'user@domain.com';
 


### PR DESCRIPTION
In reference to ticket #7 "If you attempt to reset your password with an incorrect email, there is no response from the site telling you that the email is incorrect. Essentially nothing happens once you click reset. A warning should appear which advises the user that the email is not registered."

This was due to incorrect access of the response message body. Response.data was being used rather than the correct Response._body . This caused the prompt to never show up.

The corresponding test changes have also been made to assign a value to _body rather than data.